### PR TITLE
Update Tempo specific config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -241,22 +241,26 @@ type GrafanaVariablesConfig struct {
 	Workload  string `yaml:"workload" json:"workload,omitempty"`
 }
 
+type TempoConfig struct {
+	OrgID         string `yaml:"org_id" json:"org_id,omitempty"`
+	DatasourceUID string `yaml:"datasource_uid" json:"datasource_uid,omitempty"`
+}
+
 // TracingConfig describes configuration used for tracing links
 type TracingConfig struct {
-	Auth                   Auth              `yaml:"auth"`
-	Enabled                bool              `yaml:"enabled"` // Enable Tracing in Kiali
-	GrpcPort               int               `yaml:"grpc_port,omitempty"`
-	InClusterURL           string            `yaml:"in_cluster_url"`
-	IsCore                 bool              `yaml:"is_core,omitempty"`
-	Provider               TracingProvider   `yaml:"provider"`          // jaeger | tempo
-	FrontendProvider       string            `yaml:"frontend_provider"` // jaeger | grafana
-	FrontendProviderConfig map[string]string `yaml:"frontend_provider_config"`
-	NamespaceSelector      bool              `yaml:"namespace_selector"`
-	QueryScope             map[string]string `yaml:"query_scope,omitempty"`
-	QueryTimeout           int               `yaml:"query_timeout,omitempty"`
-	URL                    string            `yaml:"url"`
-	UseGRPC                bool              `yaml:"use_grpc"`
-	WhiteListIstioSystem   []string          `yaml:"whitelist_istio_system"`
+	Auth                 Auth              `yaml:"auth"`
+	Enabled              bool              `yaml:"enabled"` // Enable Tracing in Kiali
+	GrpcPort             int               `yaml:"grpc_port,omitempty"`
+	InClusterURL         string            `yaml:"in_cluster_url"`
+	IsCore               bool              `yaml:"is_core,omitempty"`
+	Provider             TracingProvider   `yaml:"provider,omitempty"` // jaeger | tempo
+	TempoConfig          TempoConfig       `yaml:"tempo_config,omitempty"`
+	NamespaceSelector    bool              `yaml:"namespace_selector"`
+	QueryScope           map[string]string `yaml:"query_scope,omitempty"`
+	QueryTimeout         int               `yaml:"query_timeout,omitempty"`
+	URL                  string            `yaml:"url"`
+	UseGRPC              bool              `yaml:"use_grpc"`
+	WhiteListIstioSystem []string          `yaml:"whitelist_istio_system"`
 }
 
 // RegistryConfig contains configuration for connecting to an external istiod.
@@ -738,19 +742,18 @@ func NewConfig() (c *Config) {
 				Auth: Auth{
 					Type: AuthTypeNone,
 				},
-				Enabled:                true,
-				GrpcPort:               9095,
-				InClusterURL:           "http://tracing.istio-system:16685/jaeger",
-				IsCore:                 false,
-				Provider:               JaegerProvider,
-				FrontendProvider:       string(JaegerProvider),
-				FrontendProviderConfig: map[string]string{},
-				NamespaceSelector:      true,
-				QueryScope:             map[string]string{},
-				QueryTimeout:           5,
-				URL:                    "",
-				UseGRPC:                true,
-				WhiteListIstioSystem:   []string{"jaeger-query", "istio-ingressgateway"},
+				Enabled:              true,
+				GrpcPort:             9095,
+				InClusterURL:         "http://tracing.istio-system:16685/jaeger",
+				IsCore:               false,
+				Provider:             JaegerProvider,
+				NamespaceSelector:    true,
+				QueryScope:           map[string]string{},
+				QueryTimeout:         5,
+				TempoConfig:          TempoConfig{},
+				URL:                  "",
+				UseGRPC:              true,
+				WhiteListIstioSystem: []string{"jaeger-query", "istio-ingressgateway"},
 			},
 		},
 		IstioLabels: IstioLabels{

--- a/frontend/src/types/StatusState.ts
+++ b/frontend/src/types/StatusState.ts
@@ -10,10 +10,14 @@ export enum StatusKey {
 
 export type Status = { [K in StatusKey]?: string };
 
+export type TempoConfig = {
+  datasource_uid: string;
+  org_id: string;
+};
+
 export interface ExternalServiceInfo {
-  frontendProvider?: string;
-  frontendProviderConfig?: Record<string, string>;
   name: string;
+  tempoConfig?: TempoConfig;
   url?: string;
   version?: string;
 }

--- a/frontend/src/utils/tracing/UrlProviders/Tempo.ts
+++ b/frontend/src/utils/tracing/UrlProviders/Tempo.ts
@@ -1,18 +1,17 @@
 import { ConcreteService, TracingUrlProvider, TEMPO, GRAFANA, JAEGER } from 'types/Tracing';
-import { ExternalServiceInfo } from 'types/StatusState';
+import { ExternalServiceInfo, TempoConfig } from 'types/StatusState';
 import { BoundsInMilliseconds } from 'types/Common';
 import { GrafanaLegacyUrlProvider } from './GrafanaLegacy';
 import { GrafanaUrlProvider } from './Grafana';
 import { SpanData, TraceData } from 'types/TracingInfo';
 
 interface TempoExternalService extends ConcreteService {
-  frontendProvider: string;
-  frontendProviderConfig?: Record<string, string>;
   name: typeof TEMPO;
+  tempoConfig?: TempoConfig;
 }
 
 export function isTempoService(svc: ExternalServiceInfo): svc is TempoExternalService {
-  return svc.name === TEMPO && svc.frontendProvider === GRAFANA;
+  return svc.name === TEMPO;
 }
 
 class nullProvider implements TracingUrlProvider {
@@ -42,11 +41,11 @@ export class TempoUrlProvider implements TracingUrlProvider {
     let frontendProvider: TracingUrlProvider | undefined = undefined;
     const svc = externalServices.find(s => [GRAFANA, JAEGER].includes(s.name.toLowerCase()));
     if (svc && svc.name.toLowerCase() === GRAFANA && svc.url !== undefined) {
-      if (service.frontendProviderConfig?.['datasource_uid'] !== undefined) {
+      if (service.tempoConfig?.datasource_uid !== undefined) {
         // Grafana 10+
         frontendProvider = new GrafanaUrlProvider(svc.url, {
-          datasource_uid: service.frontendProviderConfig['datasource_uid'],
-          orgID: service.frontendProviderConfig['org_id']
+          datasource_uid: service.tempoConfig.datasource_uid,
+          orgID: service.tempoConfig.org_id
         });
       } else {
         // Fallback to older Grafana URL schema

--- a/handlers/tracing.go
+++ b/handlers/tracing.go
@@ -18,11 +18,13 @@ import (
 func GetTracingInfo(w http.ResponseWriter, r *http.Request) {
 	tracingConfig := config.Get().ExternalServices.Tracing
 	var info models.TracingInfo
+
 	if tracingConfig.Enabled {
 		info = models.TracingInfo{
 			Enabled:              true,
 			Integration:          tracingConfig.InClusterURL != "",
 			Provider:             string(tracingConfig.Provider),
+			TempoConfig:          tracingConfig.TempoConfig,
 			URL:                  tracingConfig.URL,
 			NamespaceSelector:    tracingConfig.NamespaceSelector,
 			WhiteListIstioSystem: tracingConfig.WhiteListIstioSystem,

--- a/models/tracing.go
+++ b/models/tracing.go
@@ -1,14 +1,19 @@
 package models
 
-import "time"
+import (
+	"time"
+
+	"github.com/kiali/kiali/config"
+)
 
 type TracingInfo struct {
-	Enabled              bool     `json:"enabled"`
-	Integration          bool     `json:"integration"`
-	Provider             string   `json:"provider"`
-	URL                  string   `json:"url"`
-	NamespaceSelector    bool     `json:"namespaceSelector"`
-	WhiteListIstioSystem []string `json:"whiteListIstioSystem"`
+	Enabled              bool               `json:"enabled"`
+	Integration          bool               `json:"integration"`
+	Provider             string             `json:"provider"`
+	TempoConfig          config.TempoConfig `json:"tempoConfig"`
+	URL                  string             `json:"url"`
+	NamespaceSelector    bool               `json:"namespaceSelector"`
+	WhiteListIstioSystem []string           `json:"whiteListIstioSystem"`
 }
 
 type TracingQuery struct {

--- a/status/status.go
+++ b/status/status.go
@@ -80,8 +80,7 @@ type ExternalServiceInfo struct {
 	// example: jaeger-query-istio-system.127.0.0.1.nip.io
 	Url string `json:"url,omitempty"`
 
-	FrontendProvider       string            `json:"frontendProvider,omitempty"`
-	FrontendProviderConfig map[string]string `json:"frontendProviderConfig,omitempty"`
+	TempoConfig config.TempoConfig `json:"tempoConfig,omitempty"`
 }
 
 func init() {

--- a/status/versions.go
+++ b/status/versions.go
@@ -202,8 +202,7 @@ func tracingVersion() (*ExternalServiceInfo, error) {
 	product := ExternalServiceInfo{}
 	product.Name = string(tracingConfig.Provider)
 	product.Url = tracingConfig.URL
-	product.FrontendProvider = tracingConfig.FrontendProvider
-	product.FrontendProviderConfig = tracingConfig.FrontendProviderConfig
+	product.TempoConfig = tracingConfig.TempoConfig
 
 	return &product, nil
 }

--- a/tracing/otel/model/converter/converter.go
+++ b/tracing/otel/model/converter/converter.go
@@ -24,7 +24,7 @@ func convertSpanId(id string) jaegerModels.SpanID {
 
 // ConvertSpans
 // https://opentelemetry.io/docs/specs/otel/trace/sdk_exporters/jaeger
-func ConvertSpans(spans []otelModels.Span, serviceName string) []jaegerModels.Span {
+func ConvertSpans(spans []otelModels.Span, serviceName string, traceID string) []jaegerModels.Span {
 	var toRet []jaegerModels.Span
 	for _, span := range spans {
 
@@ -39,8 +39,7 @@ func ConvertSpans(spans []otelModels.Span, serviceName string) []jaegerModels.Sp
 			log.Errorf("Error converting duration. Skipping trace")
 			continue
 		}
-
-		jaegerTraceId := ConvertId(span.TraceID)
+		jaegerTraceId := ConvertId(traceID) // The traceID from the SpanID doesn't look to match (ex. Q3xfr1lMsbi2OX9CxUbYug==)
 		jaegerSpanId := convertSpanId(span.SpanID)
 		parentSpanId := convertSpanId(span.ParentSpanId)
 

--- a/tracing/otel/model/converter/converter_test.go
+++ b/tracing/otel/model/converter/converter_test.go
@@ -32,7 +32,7 @@ func TestConvertSpans(t *testing.T) {
 	id := getId()
 	serviceName := "kiali-traffic-generator.bookinfo"
 
-	jaegerSpans := ConvertSpans(spans, serviceName)
+	jaegerSpans := ConvertSpans(spans, serviceName, id)
 	assert.Equal(jaegerModels.SpanID(id), jaegerSpans[0].SpanID)
 	assert.Equal(serviceName, jaegerSpans[0].Process.ServiceName)
 	assert.Equal("reviews.bookinfo.svc.cluster.local:9080/*", jaegerSpans[0].OperationName)

--- a/tracing/tempo/http_client.go
+++ b/tracing/tempo/http_client.go
@@ -200,7 +200,7 @@ func convertSingleTrace(traces *otelModels.Data, id string) (*model.TracingRespo
 		tracingServiceName = getServiceName(traces.Batches[0].Resource.Attributes)
 		for _, batch := range traces.Batches {
 			serviceName := getServiceName(batch.Resource.Attributes)
-			jaegerModel.Spans = append(jaegerModel.Spans, converter.ConvertSpans(batch.ScopeSpans[0].Spans, serviceName)...)
+			jaegerModel.Spans = append(jaegerModel.Spans, converter.ConvertSpans(batch.ScopeSpans[0].Spans, serviceName, id)...)
 		}
 		jaegerModel.Matched = len(jaegerModel.Spans)
 		jaegerModel.Processes = map[jaegerModels.ProcessID]jaegerModels.Process{}


### PR DESCRIPTION
**Describe the change**

* Update the configuration options in the backend for tracing. As Grafana is the default UI for Tempo (At least from now), in order to minimize CR changes, I think we can omit the frontendProvider setting. Also, instead of a frontendProviderConfig, I've replaced for the specific TempoConfig with the specific options. As they are predefined options that should be programed, they can be predefined so they can be validated and also easier to set up.  
* Fix for the TraceID from Span

**Issue reference**

https://github.com/kiali/kiali/pull/7085